### PR TITLE
Better settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ provides:
 * syntax highlighting
 * auto-completion of links and templates with a
   [coc.nvim](https://github.com/neoclide/coc.nvim) source
+* `<plug>` mappings for text objects
+* integration with [vim-surround](https://github.com/tpope/vim-surround)
 
 Installation
 ============
@@ -57,6 +59,33 @@ adapter to plug it in other completion mechanisms. Please refer to the
 [upstream documentation of the
 API](https://github.com/neoclide/coc.nvim/wiki/Create-custom-source) used by
 this source.
+
+Text objects
+============
+
+The plugin provides text objects `<plug>(mediawiki-text-object-inside-tick)`
+and `<plug>(mediawiki-text-object-around-tick)` to operate inside or around
+italic and bold markers, and `<plug>(mediawiki-text-object-inside-heading)` and
+`<plug>(mediawiki-text-object-around-heading)` to operate inside or around
+headings respectively.
+
+Surround
+========
+
+If [vim-surround](https://github.com/tpope/vim-surround) is installed, mappings
+are created to surround text with wiki-link or template double-brackets, or
+with bold or italic ticks. The characters bound to the surround map can be
+configured with the variables
+```viml
+let g:vim_mediawiki_surround_wikilink = 'l'
+let g:vim_mediawiki_surround_template = 't'
+let g:vim_mediawiki_surround_bold = 'b'
+let g:vim_mediawiki_surround_italic = 'i'
+```
+and can be disabled by settings
+```viml
+let g:vim_mediawiki_surround = 0
+```
 
 Configuration
 =============

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ to configure the source in coc.nvim. Settings can be defined in the
     }
 }
 ```
+To further configure completion, see the [following
+section](#Completion).
 
 If you do not use coc.nvim, you may be able to use the function
 `coc#source#mediawiki#complete()` to implement an
@@ -63,11 +65,16 @@ A set of variables allows to customise the behaviour of the plugin. All
 variables can either be set globally as `g:vim_mediawiki_...` or locally for
 each buffer with `b:vim_mediawiki_...`.
 
+## Site
+
 The value of `g:vim_mediawiki_site` sets the address of the wiki to edit.
-Default:
+The default is an empty string, and you need to set this in order to use
+features such as auto-completion. Example:
 ```viml
 let g:vim_mediawiki_site = 'en.wikipedia.org'
 ```
+
+## Completion
 
 It is possible to customise which
 [namespaces](https://www.mediawiki.org/wiki/Help:Namespaces) to auto-complete.
@@ -78,11 +85,11 @@ each trigger sequence to the number of the corresponding namespace on that
 site. Example:
 ```viml
 let g:vim_mediawiki_completion_namespaces = {
-\ 'en.wikipedia.org': {
+\   'en.wikipedia.org': {
 \       '[[': 0,
 \       '{{': 10,
 \   },
-\ 'sv.wikipedia.org': {
+\   'sv.wikipedia.org': {
 \       '[[': 0,
 \       '[[File:': 6,
 \       '[[Kategori:': 14,
@@ -93,11 +100,8 @@ Only the namespaces listed in this map will be completed. A `default` entry is
 used for sites not present among the keys. The pre-defined configuration is
 ```viml
 let g:vim_mediawiki_completion_namespaces = {
-\ 'default': {
+\   'default': {
 \       '[[': 0,
-\       '{{': 10,
-\       '[[File:': 6,
-\       '[[Category:': 14,
 \   },
 \ }
 ```
@@ -107,6 +111,44 @@ merged with the global configuration, so it is not necessary to duplicate the
 whole configuration in buffer-local variables, but it is sufficient to add or
 overwrite only the desired sites. To disable completion for a site, map it to
 an empty dictionary.
+
+A complete configuration to edit the English language Wikipedia
+[would be](https://en.wikipedia.org/wiki/Wikipedia:Namespace):
+```viml
+let g:vim_mediawiki_completion_namespaces = {
+\   'en.wikipedia.org': {
+\       '[[': 0,
+\       '[[Talk:': 1,
+\       '[[User:': 2,
+\       '[[User talk:': 3,
+\       '[[Wikipedia:': 4,
+\       '[[Wikipedia talk:': 5,
+\       '[[File:': 6,
+\       '[[:File:': 6,
+\       '[[File talk:': 7,
+\       '[[MediaWiki:': 8,
+\       '[[MediaWiki talk:': 9,
+\       '[[Template:': 10,
+\       '{{': 10,
+\       '[[Template talk:': 11,
+\       '[[Help:': 12,
+\       '[[Help talk:': 13,
+\       '[[Category:': 14,
+\       '[[:Category:': 14,
+\       '[[Category talk:': 15,
+\       '[[Portal:': 100,
+\       '[[Portal talk:': 101,
+\       '[[Book:': 108,
+\       '[[Book talk:': 109,
+\       '[[Draft:': 118,
+\       '[[Draft talk:': 119,
+\       '[[TimedText:': 710,
+\       '[[TimedText talk:': 711,
+\       '[[Module:': 828,
+\       '[[Module talk:': 829,
+\   },
+\ }
+```
 
 The value of `g:vim_mediawiki_completion_prefix_length` determines the minimum
 number of characters required after the trigger sequence to trigger completion.
@@ -120,6 +162,8 @@ fetched. Default:
 ```viml
 let g:vim_mediawiki_completion_limit = 15
 ```
+
+## Mappings
 
 No mappings are set out-of-the-box. The following optional navigation mappings
 ```viml
@@ -136,6 +180,8 @@ can be enabled by setting to true the variable
 ```viml
 let g:vim_mediawiki_mappings = 1
 ```
+
+## Syntax highlighting
 
 Languages within `<source>` or `<syntaxhighlight>` tags will be highlighted. A
 list of languages (identified by their wiki name) to be ignored can be set:

--- a/autoload/mediawiki.vim
+++ b/autoload/mediawiki.vim
@@ -5,3 +5,14 @@ function! mediawiki#get_var(bufnr, name) abort
     return get(l:variables, l:var_name, g:[l:var_name])
 endfunction
 
+" Visually select a text object in the current line, delimited by a pattern
+function! mediawiki#text_object(pattern) abort
+    let l:line = getline('.')
+    let l:col = col('.')
+    let l:left = join(reverse(split(l:line[0 : l:col - 1], '.\zs')), '')
+    let l:right = l:line[l:col - 1:]
+    let l:left = l:col - match(l:left, a:pattern)
+    let l:right = l:col + match(l:right, a:pattern)
+    execute 'normal! ' . l:left . '|v' l:right . '|'
+endfunction
+

--- a/doc/vim-mediawiki.txt
+++ b/doc/vim-mediawiki.txt
@@ -8,6 +8,7 @@ CONTENTS                                              *vim-mediawiki-contents*
     Installation..................|vim-mediawiki-installation|
     Auto-completion...............|vim-mediawiki-auto-completion|
     Options.......................|vim-mediawiki-options|
+    Text objects..................|vim-mediawiki-text-objects|
     Mappings......................|vim-mediawiki-mappings|
     License.......................|vim-mediawiki-license|
 
@@ -180,6 +181,72 @@ g:vim_mediawiki_site                                    *g:vim_mediawiki_site*
 <
 
 
+g:vim_mediawiki_surround                            *g:vim_mediawiki_surround*
+                                                    *b:vim_mediawiki_surround*
+    Type: |number|
+    Default: '1'
+
+    Enable mappings for vim-surround (https://github.com/tpope/vim-surround).
+
+    Example:
+>
+    let g:vim_mediawiki_surround = 0
+<
+
+
+g:vim_mediawiki_surround_bold                  *g:vim_mediawiki_surround_bold*
+                                               *b:vim_mediawiki_surround_bold*
+    Type: |string|
+    Default: 'b'
+
+    Character mapped to surround with bold markers.
+
+    Example:
+>
+    let g:vim_mediawiki_surround_bold = 'b'
+<
+
+
+g:vim_mediawiki_surround_italic              *g:vim_mediawiki_surround_italic*
+                                             *b:vim_mediawiki_surround_italic*
+    Type: |string|
+    Default: 'b'
+
+    Character mapped to surround with italic markers.
+
+    Example:
+>
+    let g:vim_mediawiki_surround_italic = 'i'
+<
+
+
+g:vim_mediawiki_surround_template          *g:vim_mediawiki_surround_template*
+                                           *b:vim_mediawiki_surround_template*
+    Type: |string|
+    Default: 't'
+
+    Character mapped to surround with template double-braces.
+
+    Example:
+>
+    let g:vim_mediawiki_surround_template = 't'
+<
+
+
+g:vim_mediawiki_surround_wikilink          *g:vim_mediawiki_surround_wikilink*
+                                           *b:vim_mediawiki_surround_wikilink*
+    Type: |string|
+    Default: 'l'
+
+    Character mapped to surround with wiki-link markers (double square
+    brackets).
+
+    Example:
+>
+    let g:vim_mediawiki_surround_wikilink = 'l'
+<
+
+
 g:vim_mediawiki_wikilang_map                    *g:vim_mediawiki_wikilang_map*
                                                 *b:vim_mediawiki_wikilang_map*
     Type: |list|
@@ -195,10 +262,20 @@ g:vim_mediawiki_wikilang_map                    *g:vim_mediawiki_wikilang_map*
 
 
 ==============================================================================
+TEXT OBJECTS                                      *vim-mediawiki-text-objects*
+
+The plugin exposes the text objects `<plug>(mediawiki-text-object-inside-tick)`
+and `<plug>(mediawiki-text-object-around-tick)` to operate inside or around
+italic and bold markers, and `<plug>(mediawiki-text-object-inside-heading)` and
+`<plug>(mediawiki-text-object-around-heading)` to operate inside or around
+headings respectively.
+
+
+==============================================================================
 MAPPINGS                                              *vim-mediawiki-mappings*
 
-No mappings are set out-of-the-box. The following optional mappings can
-be enabled with |g:vim_mediawiki_mappings|:
+No mappings are set out-of-the-box. The following optional
+mappings can be enabled with |g:vim_mediawiki_mappings|:
 
     nnoremap <buffer> k gk
     nnoremap <buffer> j gj

--- a/doc/vim-mediawiki.txt
+++ b/doc/vim-mediawiki.txt
@@ -51,11 +51,8 @@ g:vim_mediawiki_completion_namespaces  *g:vim_mediawiki_completion_namespaces*
                                        *b:vim_mediawiki_completion_namespaces*
     Type: |dict|
     Default: `{
-    \ 'default': {
+    \   'default': {
     \       '[[': 0,
-    \       '{{': 10,
-    \       '[[File:': 6,
-    \       '[[Category:': 14,
     \   },
     \ }`
 
@@ -65,7 +62,7 @@ g:vim_mediawiki_completion_namespaces  *g:vim_mediawiki_completion_namespaces*
     for sites not present among the keys. The pre-defined configuration is
 >
     let g:vim_mediawiki_completion_namespaces = {
-    \ 'default': {
+    \   'default': {
     \       '[[': 0,
     \       '{{': 10,
     \       '[[File:': 6,
@@ -83,7 +80,7 @@ g:vim_mediawiki_completion_namespaces  *g:vim_mediawiki_completion_namespaces*
     Example:
 >
     let g:vim_mediawiki_completion_namespaces = {
-    \ 'sv.wikipedia.org': {
+    \   'sv.wikipedia.org': {
     \       '[[': 0,
     \       '{{': 10,
     \       '[[File:': 6,
@@ -172,7 +169,7 @@ g:vim_mediawiki_preloaded_wikilangs      *g:vim_mediawiki_preloaded_wikilangs*
 g:vim_mediawiki_site                                    *g:vim_mediawiki_site*
                                                         *b:vim_mediawiki_site*
     Type: |string|
-    Default: `en.wikipedia.org`
+    Default: ''
 
     Address of the wiki to edit.
 

--- a/ftplugin/mediawiki.vim
+++ b/ftplugin/mediawiki.vim
@@ -53,5 +53,25 @@ if mediawiki#get_var(bufnr(''), 'mappings')
     nnoremap <buffer> A g$a
 endif
 
+" Settings for vim-surround: https://github.com/tpope/vim-surround
+if exists('g:loaded_surround') && mediawiki#get_var(bufnr(''), 'surround')
+    let b:surround_{char2nr(mediawiki#get_var(bufnr(''), 'surround_wikilink'))} = "[[\r|]]"
+    let b:surround_{char2nr(mediawiki#get_var(bufnr(''), 'surround_template'))} = "{{\r}}"
+    let b:surround_{char2nr(mediawiki#get_var(bufnr(''), 'surround_bold'))} = "'''\r'''"
+    let b:surround_{char2nr(mediawiki#get_var(bufnr(''), 'surround_italic'))} = "''\r''"
+endif
+
+" Text objects for section headings
+vnoremap <silent> <buffer> <plug>(mediawiki-text-object-inside-heading) :<C-U>silent! normal! T=vt=<CR>
+vnoremap <silent> <buffer> <plug>(mediawiki-text-object-around-heading) :<C-U>call mediawiki#text_object('\v(\=+)@<=\=(\=)@!')<CR>
+omap <silent> <buffer> <plug>(mediawiki-text-object-inside-heading) :normal vih<CR>
+omap <silent> <buffer> <plug>(mediawiki-text-object-around-heading) :normal vah<CR>
+
+" Text objects for bold and italic
+vnoremap <silent> <buffer> <plug>(mediawiki-text-object-inside-tick) :<C-U>silent! normal! T'vt'<CR>
+vnoremap <silent> <buffer> <plug>(mediawiki-text-object-around-tick) :<C-U>call mediawiki#text_object("\\v(\\'+)@<=\\'(\\')@!")<CR>
+omap <silent> <buffer> <plug>(mediawiki-text-object-inside-tick) :normal vi'<CR>
+omap <silent> <buffer> <plug>(mediawiki-text-object-around-tick) :normal va'<CR>
+
 let &cpoptions = s:keepcpo
 unlet! s:keepcpo

--- a/plugin/mediawiki.vim
+++ b/plugin/mediawiki.vim
@@ -44,6 +44,26 @@ if !exists('g:vim_mediawiki_wikilang_map')
     let g:vim_mediawiki_wikilang_map = {}
 endif
 
+if !exists('g:vim_mediawiki_surround')
+    let g:vim_mediawiki_surround = 1
+endif
+
+if !exists('g:vim_mediawiki_surround_wikilink')
+    let g:vim_mediawiki_surround_wikilink = 'l'
+endif
+
+if !exists('g:vim_mediawiki_surround_template')
+    let g:vim_mediawiki_surround_template = 't'
+endif
+
+if !exists('g:vim_mediawiki_surround_bold')
+    let g:vim_mediawiki_surround_bold = 'b'
+endif
+
+if !exists('g:vim_mediawiki_surround_italic')
+    let g:vim_mediawiki_surround_italic = 'i'
+endif
+
 augroup vim_media_wiki
     autocmd!
     autocmd Syntax mediawiki call mediawiki#fenced_languages#perform_highlighting()

--- a/plugin/mediawiki.vim
+++ b/plugin/mediawiki.vim
@@ -4,15 +4,12 @@ endif
 let g:vim_mediawiki_plugin_loaded = 1
 
 if !exists('g:vim_mediawiki_site')
-    let g:vim_mediawiki_site = 'en.wikipedia.org'
+    let g:vim_mediawiki_site = ''
 endif
 
 let s:default_namespaces = {
     \ 'default': {
     \       '[[': 0,
-    \       '{{': 10,
-    \       '[[File:': 6,
-    \       '[[Category:': 14,
     \   },
     \ }
 if !exists('g:vim_mediawiki_completion_namespaces')
@@ -28,7 +25,7 @@ if !exists('g:vim_mediawiki_completion_prefix_length')
 endif
 
 if !exists('g:vim_mediawiki_completion_limit')
-    let g:vim_mediawiki_completion_limit = 15
+    let g:vim_mediawiki_completion_limit = 50
 endif
 
 if !exists('g:vim_mediawiki_mappings')

--- a/test/test_coc_source_complete.vader
+++ b/test/test_coc_source_complete.vader
@@ -10,6 +10,12 @@ Before:
   \   },
   \ }
 
+  let options = {
+  \ 'bufnr': bufnr(''),
+  \ 'line': 'foo bar [[Some text and more]] after',
+  \ 'colnr': 20,
+  \ }
+
   let mock = NewFunctionMock()
 
 
@@ -28,12 +34,6 @@ After:
 
 " Use a mock of the Python interpreter that echoes all its arguments
 Execute(Test coc#source#mediawiki#complete()):
-  let options = {
-  \ 'bufnr': bufnr(''),
-  \ 'line': 'foo bar [[Some text and more]] after',
-  \ 'colnr': 20,
-  \ }
-
   let expected_command = join([
   \   '/testplugin/scripts/list_pages.py',
   \   '--site', g:vim_mediawiki_site,
@@ -48,4 +48,16 @@ Execute(Test coc#source#mediawiki#complete()):
   AssertEqual 1, len(mock.args[0])
   AssertEqual
   \ [{'word': expected_command, 'menu': expected_command}],
+  \ mock.args[0][0]
+
+
+Execute(Test coc#source#mediawiki#complete() with no site set):
+  let g:vim_mediawiki_site = ''
+
+  call coc#source#mediawiki#complete(options, mock.function)
+  sleep 500m
+
+  AssertEqual 1, len(mock.args[0])
+  AssertEqual
+  \ v:false,
   \ mock.args[0][0]

--- a/test/test_ftplugin.vader
+++ b/test/test_ftplugin.vader
@@ -1,15 +1,29 @@
 Before:
+  unlet! b:did_ftplugin
   let g:vim_mediawiki_mappings = 0
 
 
 After:
   unlet! b:did_ftplugin
+  unlet! g:loaded_surround
   unlet! g:vim_mediawiki_mappings
+  unlet! g:vim_mediawiki_surround
+  unlet! b:vim_mediawiki_surround_wikilink
+  unlet! b:vim_mediawiki_surround_template
+  unlet! b:vim_mediawiki_surround_bold
+  unlet! b:vim_mediawiki_surround_italic
   mapclear
 
 
 Execute(Test settings):
   runtime macros/matchit.vim
+  let g:loaded_surround = 1
+
+  let g:vim_mediawiki_surround = 1
+  let b:vim_mediawiki_surround_wikilink = 'a'
+  let b:vim_mediawiki_surround_template = 'b'
+  let b:vim_mediawiki_surround_bold = 'c'
+  let b:vim_mediawiki_surround_italic = 'd'
 
   runtime ftplugin/mediawiki.vim
 
@@ -28,6 +42,10 @@ Execute(Test settings):
   AssertEqual 1, &wrap
   AssertEqual 1, &linebreak
   AssertEqual 0, &textwidth
+  AssertEqual "[[\r|]]", b:surround_{char2nr('a')}
+  AssertEqual "{{\r}}", b:surround_{char2nr('b')}
+  AssertEqual "'''\r'''", b:surround_{char2nr('c')}
+  AssertEqual "''\r''", b:surround_{char2nr('d')}
 
 
 Execute(Test double load):
@@ -67,3 +85,75 @@ Execute(Test mappings):
   AssertMapping 'nmap', 'D', 'dg$'
   AssertMapping 'nmap', 'C', 'cg$'
   AssertMapping 'nmap', 'A', 'g$a'
+
+
+Given(Text with bold/italic delimiters):
+  Some text.
+  This is an '''example''' of text.
+  Some more text.
+Execute(Load ftplugin):
+  runtime ftplugin/mediawiki.vim
+  vmap <silent> <buffer> i' <plug>(mediawiki-text-object-inside-tick)
+  omap <buffer> i' <plug>(mediawiki-text-object-inside-tick)
+Do(Delete using text object for inside bold/italic):
+  2gg
+  18|
+  di'
+Expect(Text inside delimiters is removed):
+  Some text.
+  This is an '''''' of text.
+  Some more text.
+
+
+Given(Text with bold/italic delimiters):
+  Some text.
+  This is an '''example''' of text.
+  Some more text.
+Execute(Load ftplugin):
+  runtime ftplugin/mediawiki.vim
+  vmap <silent> <buffer> a' <plug>(mediawiki-text-object-around-tick)
+  omap <buffer> a' <plug>(mediawiki-text-object-around-tick)
+Do(Delete using text object for around bold/italic):
+  2gg
+  18|
+  da'
+Expect(Text around delimiters is removed):
+  Some text.
+  This is an  of text.
+  Some more text.
+
+
+Given(Text with heading delimiters):
+  Example text.
+  Some== Example heading ==
+  Example paragraph.
+Execute(Load ftplugin):
+  runtime ftplugin/mediawiki.vim
+  vmap <silent> <buffer> ih <plug>(mediawiki-text-object-inside-heading)
+  omap <buffer> ih <plug>(mediawiki-text-object-inside-heading)
+Do(Delete using text object for inside heading):
+  2gg
+  15|
+  dih
+Expect(Text inside delimiters is removed):
+  Example text.
+  Some====
+  Example paragraph.
+
+
+Given(Text with heading delimiters):
+  Example text.
+  Some== Example heading ==
+  Example paragraph.
+Execute(Load ftplugin):
+  runtime ftplugin/mediawiki.vim
+  vmap <silent> <buffer> ah <plug>(mediawiki-text-object-around-heading)
+  omap <buffer> ah <plug>(mediawiki-text-object-around-heading)
+Do(Delete using text object for around heading):
+  2gg
+  15|
+  dah
+Expect(Text around delimiters is removed):
+  Example text.
+  Some
+  Example paragraph.

--- a/test/test_plugin.vader
+++ b/test/test_plugin.vader
@@ -32,3 +32,8 @@ Execute(Test plugin loading):
   AssertEqual [], g:vim_mediawiki_ignored_wikilangs
   AssertEqual [], g:vim_mediawiki_preloaded_wikilangs
   AssertEqual {}, g:vim_mediawiki_wikilang_map
+  AssertEqual 1, g:vim_mediawiki_surround
+  AssertEqual 'l', g:vim_mediawiki_surround_wikilink
+  AssertEqual 't', g:vim_mediawiki_surround_template
+  AssertEqual 'b', g:vim_mediawiki_surround_bold
+  AssertEqual 'i', g:vim_mediawiki_surround_italic

--- a/test/test_plugin.vader
+++ b/test/test_plugin.vader
@@ -22,15 +22,12 @@ Execute(Test plugin loading):
     \ 'some_key': 'some_value',
     \ 'default': {
     \       '[[': 0,
-    \       '{{': 10,
-    \       '[[File:': 6,
-    \       '[[Category:': 14,
     \   },
     \ },
     \ g:vim_mediawiki_completion_namespaces
-  AssertEqual 'en.wikipedia.org', g:vim_mediawiki_site
+  AssertEqual '', g:vim_mediawiki_site
   AssertEqual 5, g:vim_mediawiki_completion_prefix_length
-  AssertEqual 15, g:vim_mediawiki_completion_limit
+  AssertEqual 50, g:vim_mediawiki_completion_limit
   AssertEqual 0, g:vim_mediawiki_mappings
   AssertEqual [], g:vim_mediawiki_ignored_wikilangs
   AssertEqual [], g:vim_mediawiki_preloaded_wikilangs


### PR DESCRIPTION
* No default site
* Site-agnostic default completion settings
* Add support to complete links to categories and files
* Set completion limit to 50 suggestions (API limit for a single query from an unregistered user).
* Implement text objects to operate inside/around headings and bold/italic markings.
* Add integration with vim-surround for links, templates, bold and italic.