### PR TITLE
Fix piped link syntax in captions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
     - "3.7"
 
 install:
-    - pip install codecov==2.0.15 covimerage==0.2.0 mwclient==0.10.0 flake8==3.7.8
+    - pip install codecov==2.0.15 covimerage==0.2.1 mwclient==0.10.0 flake8==3.7.8 coverage==4.5.4
 
 script:
     # Run Python tests

--- a/syntax/mediawiki.vim
+++ b/syntax/mediawiki.vim
@@ -121,7 +121,7 @@ syntax region wikiH6 start="^======" end="======" oneline contains=@wikiTop
 
 syntax region wikiLinkName start=/\V|\zs/ end=/\V\ze]]/          contained contains=@wikiText,@wikiTag
 syntax match  wikiLinkPage       /\v(\[\[)@<=[^|\]]+(\||\]\])@=/ contained
-syntax match  wikiLinkAttribute  /\v(\|)@<=[^|\]]+(\|)@=/        contained
+syntax match  wikiLinkAttribute  /\v(\|)@<=[^|\]\[]+(\|)@=/      contained
 syntax region wikiLink     start="\[\[" end="\v\]\].{-}([\[\],.;:#{}'`!"£$%&/()=?^|\\–—[:space:]]|$)@=" oneline contains=wikiLinkPage,wikiLinkAttribute,wikiLinkName
 
 syntax match wikiExternalLink "\vhttps?\:\/\/[A-Za-z0-9._~:\/?#\[\]@!$&'()*+,;=-]*"

--- a/test/test_syntax.vader
+++ b/test/test_syntax.vader
@@ -14,7 +14,52 @@ After:
   delfunction Cleanup
 
 
+Given mediawiki (Example text):
+  This is an example [[File:example.png|parameter|Description [[link|with pipe]] and some<ref>more</ref>]]
+
+  Example {{with template|foo=bar}} and <div class="foo">some inline HTML tag</div>
+
+  Test <math>\text{inline math} \sin{x}</math>
+
+  :<math>
+    \text{and block math}
+  </math>
+
+  Test [https://foobar.com a link]
 Execute(Test syntax):
   runtime syntax/mediawiki.vim
+  redraw
 
   AssertEqual 'mediawiki', b:current_syntax
+
+  AssertEqual 'wikiLink', SyntaxAt(1, 21)
+  AssertEqual 'wikiLinkPage', SyntaxAt(1, 25)
+  AssertEqual 'wikiLinkAttribute', SyntaxAt(1, 44)
+  AssertEqual 'wikiLinkName', SyntaxAt(1, 55)
+  AssertEqual 'wikiLinkPage', SyntaxAt(1, 64)
+  AssertEqual 'wikiLinkName', SyntaxAt(1, 75)
+
+  AssertEqual 'wikiTemplate', SyntaxAt(3, 10)
+  AssertEqual 'wikiTemplateName', SyntaxAt(3, 18)
+  AssertEqual 'wikiTemplateFieldName', SyntaxAt(3, 27)
+  AssertEqual 'wikiTemplateEqual', SyntaxAt(3, 28)
+  AssertEqual 'wikiTemplateFieldValue', SyntaxAt(3, 30)
+
+  AssertEqual 'htmlTagName', SyntaxAt(3, 41)
+  AssertEqual 'htmlArg', SyntaxAt(3, 46)
+  AssertEqual 'htmlString', SyntaxAt(3, 51)
+  AssertEqual 'htmlTagName', SyntaxAt(3, 79)
+
+  AssertEqual 'htmlTagName', SyntaxAt(5, 8)
+  AssertEqual 'texStatement', SyntaxAt(5, 14)
+  AssertEqual 'texMathText', SyntaxAt(5, 25)
+  AssertEqual 'texMathMatcher', SyntaxAt(5, 36)
+  AssertEqual 'htmlTagName', SyntaxAt(5, 42)
+
+  AssertEqual 'wikiParaFormatChar', SyntaxAt(7, 1)
+  AssertEqual 'htmlTagName', SyntaxAt(7, 5)
+  AssertEqual 'texStatement', SyntaxAt(8, 5)
+  AssertEqual 'htmlTagName', SyntaxAt(9, 5)
+
+  AssertEqual 'wikiExternalLink', SyntaxAt(11, 9)
+  AssertEqual 'wikiExternalLinkName', SyntaxAt(11, 29)


### PR DESCRIPTION
* Fix a bug where a piped link inside a caption would break the syntax
  highlighting within the caption itself.
* Add some unit tests for the syntax regions.

Resolves #9 