### PR TITLE
Add surround command for FORMATNUM

### DIFF
--- a/doc/vim-mediawiki.txt
+++ b/doc/vim-mediawiki.txt
@@ -268,6 +268,19 @@ g:vim_mediawiki_surround_italic              *g:vim_mediawiki_surround_italic*
 <
 
 
+g:vim_mediawiki_surround_formatnum        *g:vim_mediawiki_surround_formatnum*
+                                          *b:vim_mediawiki_surround_formatnum*
+    Type: |string|
+    Default: 'f'
+
+    Character mapped to surround a number with {{FORMATNUM:}}.
+
+    Example:
+>
+    let g:vim_mediawiki_surround_formatnum = 'f'
+<
+
+
 g:vim_mediawiki_surround_template          *g:vim_mediawiki_surround_template*
                                            *b:vim_mediawiki_surround_template*
     Type: |string|

--- a/ftplugin/mediawiki.vim
+++ b/ftplugin/mediawiki.vim
@@ -72,6 +72,7 @@ if exists('g:loaded_surround') && mediawiki#get_var(bufnr(''), 'surround')
     let b:surround_{char2nr(mediawiki#get_var(bufnr(''), 'surround_template'))} = "{{\r}}"
     let b:surround_{char2nr(mediawiki#get_var(bufnr(''), 'surround_bold'))} = "'''\r'''"
     let b:surround_{char2nr(mediawiki#get_var(bufnr(''), 'surround_italic'))} = "''\r''"
+    let b:surround_{char2nr(mediawiki#get_var(bufnr(''), 'surround_formatnum'))} = "{{FORMATNUM:\r}}"
 endif
 
 " Text objects for section headings

--- a/plugin/mediawiki.vim
+++ b/plugin/mediawiki.vim
@@ -64,6 +64,10 @@ if !exists('g:vim_mediawiki_surround_italic')
     let g:vim_mediawiki_surround_italic = 'i'
 endif
 
+if !exists('g:vim_mediawiki_surround_formatnum')
+    let g:vim_mediawiki_surround_formatnum = 'f'
+endif
+
 if !exists('g:vim_mediawiki_browser_command')
     let g:vim_mediawiki_browser_command = "firefox \r"
 endif

--- a/test/test_ftplugin.vader
+++ b/test/test_ftplugin.vader
@@ -26,6 +26,7 @@ Execute(Test settings):
   let g:vim_mediawiki_surround_template = 'b'
   let g:vim_mediawiki_surround_bold = 'c'
   let g:vim_mediawiki_surround_italic = 'd'
+  let g:vim_mediawiki_surround_formatnum = 'e'
 
   runtime ftplugin/mediawiki.vim
 
@@ -48,6 +49,7 @@ Execute(Test settings):
   AssertEqual "{{\r}}", b:surround_{char2nr('b')}
   AssertEqual "'''\r'''", b:surround_{char2nr('c')}
   AssertEqual "''\r''", b:surround_{char2nr('d')}
+  AssertEqual "{{FORMATNUM:\r}}", b:surround_{char2nr('e')}
 
 
 Execute(Test double load):

--- a/test/test_plugin.vader
+++ b/test/test_plugin.vader
@@ -38,5 +38,6 @@ Execute(Test plugin loading):
   AssertEqual 't', g:vim_mediawiki_surround_template
   AssertEqual 'b', g:vim_mediawiki_surround_bold
   AssertEqual 'i', g:vim_mediawiki_surround_italic
+  AssertEqual 'f', g:vim_mediawiki_surround_formatnum
   AssertEqual "firefox \r", g:vim_mediawiki_browser_command
   AssertEqual {'default': 'vector'}, g:vim_mediawiki_skins


### PR DESCRIPTION
Add a [vim-surround](https://github.com/tpope/vim-surround) binding to surround a number with the {{FORMATNUM:}} [magic word](https://www.mediawiki.org/wiki/Help:Magic_words).