### PR TITLE
Implement template parameter name completion

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
 ignore:
   - "test"
   - "ftdetect"

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ profile_file*
 coverage.xml
 python_output
 browser_output
+codecov_validation

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ script:
     # Run vimscript tests
     - ./run_tests.sh --profile
 
+    # Validate Codecov configuration
+    - curl --data-binary @.codecov.yml https://codecov.io/validate | tee codecov_validation
+    - head -n 1 codecov_validation | grep 'Valid!'
+
+
 after_success: |
     set -eo pipefail
     for vim in vim neovim; do

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ provides:
 * filetype detection
 * improved syntax highlighting
 * page preview
-* auto-completion of links and templates with a
+* semantic auto-completion of links and templates with a
   [coc.nvim](https://github.com/neoclide/coc.nvim) source
 * [UltiSnips](https://github.com/SirVer/ultisnips) snippets
 * `<plug>` mappings for text objects
@@ -35,6 +35,13 @@ completions will be suggested when typing more than one word inside the
 brackets, together with a hint of the full page name.
 
 ![image](https://user-images.githubusercontent.com/8300317/68047476-2894dc00-fce7-11e9-9f7f-9be1c0485616.png)
+
+When inserting a template, semantic completion of parameter names is provided,
+and the documentation for each parameter is provided in the floating window,
+based on the
+[TemplateData](https://www.mediawiki.org/wiki/Extension:TemplateData) API.
+
+![image](https://user-images.githubusercontent.com/8300317/77249684-35d54780-6c43-11ea-9d39-aa16d7a983e1.png)
 
 You can refer to the relevant [upstream
 documentation](https://github.com/neoclide/coc.nvim/wiki/Completion-with-sources)

--- a/autoload/coc/source/mediawiki.vim
+++ b/autoload/coc/source/mediawiki.vim
@@ -1,6 +1,82 @@
-let s:script = expand('<sfile>:p:h:h:h:h') . '/scripts/list_pages.py'
+let s:script_folder = expand('<sfile>:p:h:h:h:h') . '/scripts'
+let s:list_pages_script = s:script_folder . '/list_pages.py'
+let s:get_templatedata_script = s:script_folder . '/get_templatedata.py'
+let s:completion_cache = {}
 
-" Get the completion prefix at cursor position
+" Run an external command and handle its output with the given callback
+"
+" Use an asynchronous job if possible.
+function! s:job(command, stdout_cb) abort
+    if has('nvim')
+        call jobstart(a:command, {
+        \   'on_stdout': a:stdout_cb,
+        \   'stdout_buffered': 1,
+        \ })
+    elseif has('job')
+        call job_start(a:command, {
+        \   'out_cb': {_, msg -> a:stdout_cb(0, split(msg, '\n') + [''], 0)},
+        \   'out_mode': 'raw',
+        \ })
+    else
+        call a:stdout_cb(0, systemlist(a:command), 0)
+    endif
+endfunction
+
+" Check if the cursor is inserting in a template
+"
+" Note: This is a best-effort heuristic. It checks the syntax
+" region of the character before the cursor position (to avoid getting
+" no syntax region when the cursor is inserting at the end of a line).
+" When the cursor is inserting inside a template, the character before
+" is expected to be part of the template syntax. This will fail for
+" instance when inserting in an empty line, but this is not considered
+" an important case for completion.
+function! s:not_inside_template() abort
+    return synIDattr(synID(line('.'), col('.') - 1, 0), 'name') !~# '^wikiTemplate'
+endfunction
+
+" Return the name of the template surrounding the cursor
+"
+" If the cursor is inside a wiki template, return its name, or v:null
+" otherwise.
+"
+" Note: This is a best-effort implementation, that considers the closest
+" pair of braces as template boundaries. It may fail, for instance, when
+" invoked with the cursor located inside a pair of curly braces
+" contained somewhere within a template. However, this implementation
+" should be good enough for its use case (template parameter
+" completion), since the cursor is expected to be within a parameter
+" name and no braces should be normally present there.
+function! s:get_template_name() abort
+    if s:not_inside_template()
+        return v:null
+    endif
+
+    try
+        let l:saved_curpos = getpos('.')
+        let l:saved_clipboard = &clipboard
+        set clipboard=
+        let l:saved_reg = getreg('"')
+        let l:saved_regmode = getregtype('"')
+        silent keepjumps normal! yi}
+        let l:text = @@
+    finally
+        call setpos('.', l:saved_curpos)
+        call setreg('"', l:saved_reg, l:saved_regmode)
+        let &clipboard = l:saved_clipboard
+    endtry
+
+    let l:res = matchlist(l:text, '\v^([^|]+)\|')
+    if len(l:res) < 2
+        return v:null
+    endif
+
+    " 'Template:' works as namespace prefix regardless of the
+    " localisation of the MediaWiki installation
+    return substitute(trim(l:res[1]), '\v^([^:]+\:)?', 'Template:', '')
+endfunction
+
+" Get the completion prefix for a page at cursor position
 "
 " The namespace prefix is one of the keys in the namespaces dictionary,
 " e.g. for wikilinks it is '[[', for templates '{{', for files '[[File:'
@@ -9,7 +85,7 @@ let s:script = expand('<sfile>:p:h:h:h:h') . '/scripts/list_pages.py'
 "
 " When looking for the opening signs, avoid matching `{{{` (template
 " arguments) and `{{#` (magic words).
-function! s:get_prefix(options) abort
+function! s:get_page_prefix(options) abort
     let l:namespaces = keys(mediawiki#get_site_var(a:options.bufnr, 'completion_namespaces'))
     let l:min_prefix_length = mediawiki#get_var(a:options.bufnr, 'completion_prefix_length')
     for l:namespace in reverse(sort(l:namespaces))
@@ -25,8 +101,43 @@ function! s:get_prefix(options) abort
     return []
 endfunction
 
+" Get the completion prefix for a template parameter
+function! s:get_template_parameter_prefix(options) abort
+    if s:not_inside_template()
+        return v:null
+    endif
+
+    let l:match = matchlist(a:options.line[0:a:options.colnr - 2], '\v\|([^=|]*)$')
+    return len(l:match) > 1 ? trim(l:match[1]) : v:null
+endfunction
+
+" Get a localised string
+"
+" Given a dictionary of localised messages, return:
+" - the message in the current locale (if available);
+" - if not, the message in English (if available);
+" - if not, the message in the first language available.
+"
+" If the input is not a dictionary, return its conversion to string.
+function! s:get_local_message(messages) abort
+    if type(a:messages) == type(v:null)
+        return ''
+    elseif type(a:messages) != v:t_dict
+        return string(a:messages)
+    endif
+
+    let l:lang = v:lang[0:1]
+    if has_key(a:messages, l:lang)
+        return a:messages[l:lang]
+    elseif has_key(a:messages, 'en')
+        return a:messages['en']
+    else
+        return a:messages[keys(a:messages)[0]]
+    endif
+endfunction
+
 " Handle results from the API query
-function! s:handler(prefix, callback, channel, data, stream) abort
+function! s:handle_pages(prefix, callback, channel, data, stream) abort
     call filter(a:data, {i, v -> v !~# '\v^\s*$'})
     if len(a:data) < 1
         call a:callback(v:false)
@@ -47,6 +158,115 @@ function! s:handler(prefix, callback, channel, data, stream) abort
     call a:callback(a:data)
 endfunction
 
+" Format menu entry from template data
+function! s:get_menu(name, data) abort
+    let l:result = ''
+
+    if has_key(a:data, 'label') && type(a:data.label) != type(v:null)
+        let l:result .= trim(s:get_local_message(a:data.label))
+    else
+        let l:result .= a:name
+    endif
+
+    if has_key(a:data, 'deprecated') && a:data.deprecated
+        let l:result .= ' (deprecated)'
+    endif
+
+    return l:result
+endfunction
+
+" Format info entry from template data
+function! s:get_info(data) abort
+    let l:result = []
+
+    let l:description = ''
+    if has_key(a:data, 'description')
+        let l:description = trim(s:get_local_message(a:data.description))
+    endif
+    if l:description !=? ''
+        let l:result += [l:description, '']
+    endif
+
+    if has_key(a:data, 'default') && type(a:data.default) != type(v:null)
+        let l:result += ['Default: ' . s:get_local_message(a:data.default)]
+    endif
+
+    if has_key(a:data, 'example') && type(a:data.example) != type(v:null)
+        let l:result += ['Example: ' . s:get_local_message(a:data.example)]
+    endif
+
+    if has_key(a:data, 'aliases') && len(a:data.aliases) > 0
+        let l:result += ['Aliases: ' . join(a:data.aliases, ', ')]
+    endif
+
+    return join(l:result, "\n")
+endfunction
+
+" Handle results from the API query
+function! s:handle_template_parameters(bufnr, template_name, callback, channel, data, stream) abort
+    let l:templatedata = {}
+    try
+        let l:templatedata = json_decode(join(a:data, "\n"))
+    catch
+        call a:callback(v:false)
+        return
+    endtry
+
+    if type(l:templatedata) != v:t_dict || l:templatedata == {}
+        call a:callback(v:false)
+        return
+    endif
+
+    call map(l:templatedata, {name, data -> {
+    \   'word': name,
+    \   'menu': s:get_menu(name, data),
+    \   'info': s:get_info(data),
+    \ }})
+    let l:completions = values(l:templatedata)
+
+    if !has_key(s:completion_cache, a:bufnr)
+        let s:completion_cache[a:bufnr] = {}
+    endif
+    let s:completion_cache[a:bufnr][a:template_name] = l:completions
+
+    call a:callback(l:completions)
+endfunction
+
+" Provide completions for template parameter names
+function! s:template_completion(bufnr, site, callback) abort
+    let l:template_name = s:get_template_name()
+
+    if has_key(s:completion_cache, a:bufnr) &&
+    \  has_key(s:completion_cache[a:bufnr], l:template_name)
+        call a:callback(s:completion_cache[a:bufnr][l:template_name])
+        return
+    endif
+
+    let l:command = [
+    \   'python', s:get_templatedata_script,
+    \   '--site', a:site,
+    \   '--template', l:template_name,
+    \ ]
+
+    call s:job(l:command, function('s:handle_template_parameters', [a:bufnr, l:template_name, a:callback]))
+endfunction
+
+" Provide completions for page names
+function! s:page_completion(site, options, callback) abort
+    let l:prefix = s:get_page_prefix(a:options)
+    let l:namespace = mediawiki#get_site_var(a:options.bufnr, 'completion_namespaces')[l:prefix[0]]
+
+    let l:command = [
+    \   'python', s:list_pages_script,
+    \   '--site', a:site,
+    \   '--prefix', l:prefix[1],
+    \   '--namespace', string(l:namespace),
+    \   '--limit', string(mediawiki#get_var(a:options.bufnr, 'completion_limit')),
+    \ ]
+
+    call s:job(l:command, function('s:handle_pages', [l:prefix, a:callback]))
+endfunction
+
 " Initialise completion source
 function! coc#source#mediawiki#init() abort
     return {
@@ -59,7 +279,9 @@ endfunction
 " Check if the word should be completed, i.e. if the cursor is inside
 " double square brackets or double braces.
 function! coc#source#mediawiki#should_complete(options) abort
-    return s:get_prefix(a:options) != []
+    let l:is_page = s:get_page_prefix(a:options) != []
+    let l:is_template_parameter = s:get_template_parameter_prefix(a:options) != v:null
+    return l:is_page || l:is_template_parameter
 endfunction
 
 " Provide completions by querying the API
@@ -70,28 +292,9 @@ function! coc#source#mediawiki#complete(options, callback) abort
         call a:callback(v:false)
     endif
 
-    let l:prefix = s:get_prefix(a:options)
-    let l:namespace = mediawiki#get_site_var(a:options.bufnr, 'completion_namespaces')[l:prefix[0]]
-
-    let l:command = [
-    \   'python', s:script,
-    \   '--site', l:site,
-    \   '--prefix', l:prefix[1],
-    \   '--namespace', string(l:namespace),
-    \   '--limit', string(mediawiki#get_var(a:options.bufnr, 'completion_limit')),
-    \ ]
-
-    if has('nvim')
-        call jobstart(l:command, {
-        \   'on_stdout': function('s:handler', [l:prefix, a:callback]),
-        \   'stdout_buffered': 1,
-        \ })
-    elseif has('job')
-        call job_start(l:command, {
-        \   'out_cb': {_, msg -> s:handler(l:prefix, a:callback, 0, split(msg, '\n'), 0)},
-        \   'out_mode': 'raw',
-        \ })
+    if s:get_template_parameter_prefix(a:options) != v:null
+        call s:template_completion(a:options.bufnr, l:site, a:callback)
     else
-        call s:handler(l:prefix, a:callback, 0, systemlist(l:command), 0)
+        call s:page_completion(l:site, a:options, a:callback)
     endif
 endfunction

--- a/doc/vim-mediawiki.txt
+++ b/doc/vim-mediawiki.txt
@@ -40,6 +40,12 @@ properly, the completion source should work out-of-the-box for buffers of type
 or double braces. Multi-word completion is supported, so completions will be
 suggested when typing more than one word inside the brackets.
 
+When inserting a template parameter name, auto-completion suggestions based on
+TemplateData (https://www.mediawiki.org/wiki/Extension:TemplateData) will be
+provided if the MediaWiki installation of the wiki being edited has the
+TemplateData extension and if the TemplateData fields on the wiki are correctly
+compiled for the desired template.
+
 
 ==============================================================================
 COMMANDS                                              *vim-mediawiki-commands*

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -17,7 +17,7 @@ docker images -q "${docker_image}" | grep "^${docker_image_id}" > /dev/null \
     || docker pull "${docker_image}"
 
 vim_binaries=$(docker run --rm "${docker_image}" ls /vim-build/bin \
-             | grep -E '^(neo)?vim-v(8\.1|0)' )
+             | grep -E '^(neo)?vim-v(8\.1|0\.3)' )
 
 set +e
 exit_status=0

--- a/scripts/get_templatedata.py
+++ b/scripts/get_templatedata.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+r'''
+Query the MediaWiki API to get TemplateData for a given template.
+Output the JSON schema for the template to stdout.
+'''
+
+import argparse
+import json
+import sys
+
+import mwclient
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--site', type=str, required=True,
+                        help='Address of the MediaWiki site to query')
+    parser.add_argument('--template', type=str, required=True,
+                        help='Desired template name (inclusive of namespace)')
+    args = parser.parse_args(argv)
+
+    site = mwclient.Site(args.site)
+
+    kwargs = {
+        'titles': args.template,
+        'format': 'jsonfm',
+        'redirects': True,
+    }
+
+    result = site.api('templatedata', **kwargs)
+
+    output = {}
+
+    if result and 'pages' in result and result['pages']:
+        for p in result['pages'].values():
+            output.update(p['params'])
+
+    print(json.dumps(output))
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/test/test_coc_source_complete.vader
+++ b/test/test_coc_source_complete.vader
@@ -15,12 +15,6 @@ Before:
   \   },
   \ }
 
-  let options = {
-  \ 'bufnr': bufnr(''),
-  \ 'line': 'foo bar [[Some text and more]] after',
-  \ 'colnr': 20,
-  \ }
-
   let mock = NewFunctionMock()
 
 
@@ -30,27 +24,14 @@ After:
   unlet! expected_command
 
 
-" Use a mock of the Python interpreter that echoes all its arguments
-Execute(Test coc#source#mediawiki#complete()):
-  let expected_command = join([
-  \   '/testplugin/scripts/list_pages.py',
-  \   '--site', g:vim_mediawiki_site,
-  \   '--prefix', 'Some text',
-  \   '--namespace', string(g:vim_mediawiki_completion_namespaces['default']['[[']),
-  \   '--limit', string(g:vim_mediawiki_completion_limit),
-  \   ], ' ')
-
-  call coc#source#mediawiki#complete(options, mock.function)
-  sleep 500m
-
-  AssertEqual 1, len(mock.args[0])
-  AssertEqual
-  \ [{'word': expected_command, 'menu': expected_command}],
-  \ mock.args[0][0]
-
-
 Execute(Test coc#source#mediawiki#complete() with no site set):
   let g:vim_mediawiki_site = ''
+
+  let options = {
+  \ 'bufnr': bufnr(''),
+  \ 'line': 'foo bar [[Some text and more]] after',
+  \ 'colnr': 20,
+  \ }
 
   call coc#source#mediawiki#complete(options, mock.function)
   sleep 500m

--- a/test/test_coc_source_get_info.vader
+++ b/test/test_coc_source_get_info.vader
@@ -1,0 +1,45 @@
+Before:
+  let b:script = 'autoload/coc/source/mediawiki.vim'
+  source test/utils.vim
+
+  call ClearSettings()
+
+  let Function = GetFunction(b:script, 'get_info')
+
+
+After:
+  unlet! Function
+
+  unlet! data
+
+
+Execute(Test s:get_info() with no data):
+  let data = {}
+
+  AssertEqual
+  \ '',
+  \ Function(data)
+
+
+Execute(Test s:get_info() with only description):
+  let data = {
+  \   'description': {'en': 'Some description'},
+  \ }
+
+  AssertEqual
+  \ "Some description\n",
+  \ Function(data)
+
+
+Execute(Test s:get_info() with full data):
+  let data = {
+  \   'description': {'en': 'Some description'},
+  \   'default': {'en': 'Some default'},
+  \   'example': {'en': 'Some example'},
+  \   'aliases': ['some', 'aliases'],
+  \ }
+
+  AssertEqual
+  \ "Some description\n\nDefault: Some default\nExample: Some example\nAliases: some, aliases",
+  \ Function(data)
+

--- a/test/test_coc_source_get_local_message.vader
+++ b/test/test_coc_source_get_local_message.vader
@@ -1,0 +1,64 @@
+Before:
+  let b:script = 'autoload/coc/source/mediawiki.vim'
+  source test/utils.vim
+
+  call ClearSettings()
+
+  let Function = GetFunction(b:script, 'get_local_message')
+
+
+After:
+  unlet! Function
+
+  unlet! messages
+
+
+Execute(Test s:get_local_message() on v:null):
+
+  let messages = v:null
+
+  AssertEqual
+  \ '',
+  \ Function(messages)
+
+
+Execute(Test s:get_local_message() on string):
+
+  let messages = 'Some message'
+
+  AssertEqual
+  \ string(messages),
+  \ Function(messages)
+
+
+Execute(Test s:get_local_message() on list):
+
+  let messages = ['foo', 2]
+
+  AssertEqual
+  \ string(messages),
+  \ Function(messages)
+
+
+Execute(Test s:get_local_message() with English available):
+
+  let messages = {
+  \   'en': 'message_en',
+  \   'xx': 'message_xx',
+  \ }
+
+  AssertEqual
+  \ 'message_en',
+  \ Function(messages)
+
+
+Execute(Test s:get_local_message() with English unavailable):
+
+  let messages = {
+  \   'xx': 'message_xx',
+  \ }
+
+  AssertEqual
+  \ 'message_xx',
+  \ Function(messages)
+

--- a/test/test_coc_source_get_menu.vader
+++ b/test/test_coc_source_get_menu.vader
@@ -1,0 +1,48 @@
+Before:
+  let b:script = 'autoload/coc/source/mediawiki.vim'
+  source test/utils.vim
+
+  call ClearSettings()
+
+  let Function = GetFunction(b:script, 'get_menu')
+
+
+After:
+  unlet! Function
+
+  unlet! name
+  unlet! data
+
+
+Execute(Test s:get_menu() with only name):
+  let name = 'Some name'
+  let data = {}
+
+  AssertEqual
+  \ 'Some name',
+  \ Function(name, data)
+
+
+Execute(Test s:get_menu() with label):
+  let name = 'Some name'
+  let data = {
+  \   'label': {'en': 'Some label'},
+  \ }
+
+  AssertEqual
+  \ "Some label",
+  \ Function(name, data)
+
+
+Execute(Test s:get_menu() with deprecation):
+  let name = 'Some name'
+  let data = {
+  \   'label': {'en': 'Some label'},
+  \   'deprecated': v:true,
+  \ }
+
+  AssertEqual
+  \ 'Some label (deprecated)',
+  \ Function(name, data)
+
+

--- a/test/test_coc_source_get_page_prefix.vader
+++ b/test/test_coc_source_get_page_prefix.vader
@@ -4,7 +4,7 @@ Before:
 
   call ClearSettings()
 
-  let Function = GetFunction(b:script, 'get_prefix')
+  let Function = GetFunction(b:script, 'get_page_prefix')
 
   let g:vim_mediawiki_site = 'some_site'
   let g:vim_mediawiki_completion_prefix_length = 5

--- a/test/test_coc_source_get_template_name.vader
+++ b/test/test_coc_source_get_template_name.vader
@@ -1,0 +1,97 @@
+Before:
+  let b:script = 'autoload/coc/source/mediawiki.vim'
+  source test/utils.vim
+
+  call ClearSettings()
+  call ClearSyntax()
+
+  runtime syntax/mediawiki.vim
+  redraw
+
+  let Function = GetFunction(b:script, 'get_template_name')
+
+
+After:
+  call ClearSettings()
+  call ClearSyntax()
+
+  unlet! b:script
+
+  unlet! Function
+
+
+Given (Example text):
+  Example {{with|inline=template}} and {{ padded | with = spaces }}.
+
+  {{Example
+  |with
+  |template=out
+   | of = lines
+  }}
+
+  Test {{template}} with no arguments.
+
+  Test <math>\text{inline math} \sin{x}</math>
+Execute(Test s:get_template_name() within text):
+  call cursor(1, 5)
+  AssertEqual v:null, Function()
+
+Execute(Test s:get_template_name() within emtpy line):
+  call cursor(2, 1)
+  AssertEqual v:null, Function()
+
+Execute(Test s:get_template_name() within parameter with no arguments):
+  call cursor(9, 13)
+  AssertEqual v:null, Function()
+
+Execute(Test s:get_template_name() within math):
+  call cursor(11, 22)
+  AssertEqual v:null, Function()
+
+Execute(Test s:get_template_name() at the beginning on inline template):
+  call cursor(1, 11)
+  AssertEqual 'Template:with', Function()
+
+Execute(Test s:get_template_name() in the middle on inline template):
+  call cursor(1, 16)
+  AssertEqual 'Template:with', Function()
+
+Execute(Test s:get_template_name() at the end on inline template):
+  call cursor(1, 30)
+  AssertEqual 'Template:with', Function()
+
+Execute(Test s:get_template_name() at the beginning of parameter of inline template with spaces):
+  call cursor(1, 49)
+  AssertEqual 'Template:padded', Function()
+
+Execute(Test s:get_template_name() at end of parameter of inline template with spaces):
+  call cursor(1, 54)
+  AssertEqual 'Template:padded', Function()
+
+Execute(Test s:get_template_name() at the beginning of out-of-line template):
+  call cursor(3, 3)
+  AssertEqual 'Template:Example', Function()
+
+Execute(Test s:get_template_name() at the beginning of anonymous parameter in out-of-line template):
+  call cursor(4, 2)
+  AssertEqual 'Template:Example', Function()
+
+Execute(Test s:get_template_name() at the end of anonymous parameter in out-of-line template):
+  call cursor(4, 6)
+  AssertEqual 'Template:Example', Function()
+
+Execute(Test s:get_template_name() at the beginning of named parameter in out-of-line template):
+  call cursor(5, 2)
+  AssertEqual 'Template:Example', Function()
+
+Execute(Test s:get_template_name() at the end of named parameter in out-of-line template):
+  call cursor(5, 11)
+  AssertEqual 'Template:Example', Function()
+
+Execute(Test s:get_template_name() at the beginning of named parameter in out-of-line template with spaces):
+  call cursor(6, 3)
+  AssertEqual 'Template:Example', Function()
+
+Execute(Test s:get_template_name() at the end of named parameter in out-of-line template with spaces):
+  call cursor(6, 7)
+  AssertEqual 'Template:Example', Function()

--- a/test/test_coc_source_get_template_parameter_prefix.vader
+++ b/test/test_coc_source_get_template_parameter_prefix.vader
@@ -1,0 +1,96 @@
+Before:
+  let b:script = 'autoload/coc/source/mediawiki.vim'
+  source test/utils.vim
+
+  call ClearSettings()
+  call ClearSyntax()
+
+  runtime syntax/mediawiki.vim
+  redraw
+
+  let Function = GetFunction(b:script, 'get_template_parameter_prefix')
+
+  function! PrepareLine(line, col)
+    let l:options = {
+    \ 'bufnr': bufnr(''),
+    \ 'line': getline(a:line),
+    \ 'colnr': a:col,
+    \ }
+
+    call cursor(a:line, a:col)
+
+    return l:options
+  endfunction
+
+
+After:
+  call ClearSettings()
+  call ClearSyntax()
+
+  unlet! b:script
+
+  delfunction PrepareLine
+
+  unlet! Function
+  unlet! options
+
+
+Given (Example text):
+  Example {{with|inline=template}} and {{ with | more = spacing }}.
+
+  {{Example
+  |with
+  |template=out
+   | of = lines
+  }}
+
+  Test <math>\text{inline math} \sin{x}</math>
+
+
+Execute(Test s:get_template_parameter_prefix() outside template):
+  let options = PrepareLine(1, 5)
+
+  AssertEqual
+  \ v:null,
+  \ Function(options)
+
+
+Execute(Test s:get_template_parameter_prefix() inside template name):
+  let options = PrepareLine(1, 13)
+
+  AssertEqual
+  \ v:null,
+  \ Function(options)
+
+
+Execute(Test s:get_template_parameter_prefix() inside inline template parameter name):
+  let options = PrepareLine(1, 19)
+
+  AssertEqual
+  \ 'inl',
+  \ Function(options)
+
+
+Execute(Test s:get_template_parameter_prefix() inside inline template parameter value):
+  let options = PrepareLine(1, 30)
+
+  AssertEqual
+  \ v:null,
+  \ Function(options)
+
+
+Execute(Test s:get_template_parameter_prefix() inside out-of-line template parameter name):
+  let options = PrepareLine(4, 4)
+
+  AssertEqual
+  \ 'wi',
+  \ Function(options)
+
+
+Execute(Test s:get_template_parameter_prefix() inside out-of-line template parameter name with space):
+  let options = PrepareLine(6, 6)
+
+  AssertEqual
+  \ 'of',
+  \ Function(options)
+

--- a/test/test_coc_source_handle_pages.vader
+++ b/test/test_coc_source_handle_pages.vader
@@ -4,7 +4,7 @@ Before:
 
   call ClearSettings()
 
-  let Function = GetFunction(b:script, 'handler')
+  let Function = GetFunction(b:script, 'handle_pages')
 
   let g:vim_mediawiki_site = 'some_site'
   let g:vim_mediawiki_completion_namespaces = {
@@ -33,7 +33,7 @@ After:
   unlet! b:vim_mediawiki_site
 
 
-Execute(Test s:handler() with no input):
+Execute(Test s:handle_pages() with no input):
   let prefix = ['[[', 'some text']
   let data = []
 
@@ -43,7 +43,7 @@ Execute(Test s:handler() with no input):
   AssertEqual [v:false], mock.args[0]
 
 
-Execute(Test s:handler() with empty input):
+Execute(Test s:handle_pages() with empty input):
   let prefix = ['[[', 'some text']
   let data = [' ']
 
@@ -53,7 +53,7 @@ Execute(Test s:handler() with empty input):
   AssertEqual [v:false], mock.args[0]
 
 
-Execute(Test s:handler() with wikilink input):
+Execute(Test s:handle_pages() with wikilink input):
   let prefix = ['[[', 'some example text']
   let data = [
   \   'some example text with a completion',
@@ -78,7 +78,7 @@ Execute(Test s:handler() with wikilink input):
   AssertEqual expected, mock.args[0][0]
 
 
-Execute(Test s:handler() with template input):
+Execute(Test s:handle_pages() with template input):
   let prefix = ['{{', 'some example text']
   let data = [
   \   'Template:some example text with a completion',
@@ -103,7 +103,7 @@ Execute(Test s:handler() with template input):
   AssertEqual expected, mock.args[0][0]
 
 
-Execute(Test s:handler() with file input):
+Execute(Test s:handle_pages() with file input):
   let prefix = ['[[File:', 'some example text']
   let data = [
   \   'File:some example text with a completion',

--- a/test/test_coc_source_handle_template_parameters.vader
+++ b/test/test_coc_source_handle_template_parameters.vader
@@ -1,0 +1,97 @@
+Before:
+  let b:script = 'autoload/coc/source/mediawiki.vim'
+  source test/utils.vim
+
+  let Function = GetFunction(b:script, 'handle_template_parameters')
+
+  let mock = NewFunctionMock()
+
+  let template_name = 'template_name'
+  let bufnr = 10
+
+After:
+  unlet! b:script
+
+  unlet! Function
+  unlet! mock
+  unlet! template_name
+  unlet! bufnr
+  unlet! data
+  unlet! expected
+
+
+Execute(Test s:handle_template_parameters() with no input):
+  let data = []
+
+  call Function(bufnr, template_name, mock.function, 0, data, 0)
+
+  AssertEqual 1, mock.count
+  AssertEqual [v:false], mock.args[0]
+
+
+Execute(Test s:handle_template_parameters() with empty input):
+  let data = [' ']
+
+  call Function(bufnr, template_name, mock.function, 0, data, 0)
+
+  AssertEqual 1, mock.count
+  AssertEqual [v:false], mock.args[0]
+
+
+Execute(Test s:handle_template_parameters() with valid input):
+  let data = [
+  \  '{',
+  \  '    "parameter1": {',
+  \  '        "label": {',
+  \  '            "it": "Some label 1"',
+  \  '        },',
+  \  '        "description": {',
+  \  '            "it": "Some description 1"',
+  \  '        },',
+  \  '        "type": "string",',
+  \  '        "required": false,',
+  \  '        "suggested": false,',
+  \  '        "example": null,',
+  \  '        "deprecated": false,',
+  \  '        "aliases": [],',
+  \  '        "autovalue": null,',
+  \  '        "default": null',
+  \  '    },',
+  \  '    "parameter2": {',
+  \  '        "label": null,',
+  \  '        "required": false,',
+  \  '        "suggested": false,',
+  \  '        "description": null,',
+  \  '        "example": {',
+  \  '            "en": "Some example"',
+  \  '        },',
+  \  '        "deprecated": true,',
+  \  '        "aliases": ["foo", "bar"],',
+  \  '        "autovalue": null,',
+  \  '        "default": {',
+  \  '            "en": "Some default"',
+  \  '        },',
+  \  '        "type": "unknown"',
+  \  '    }',
+  \  '}',
+  \ ]
+
+  let expected = [
+  \   {
+  \     'menu': 'Some label 1',
+  \     'word': 'parameter1',
+  \     'info': "Some description 1\n",
+  \   },
+  \   {
+  \     'menu': 'parameter2 (deprecated)',
+  \     'word': 'parameter2',
+  \     'info': "Default: Some default\nExample: Some example\nAliases: foo, bar",
+  \   },
+  \ ]
+
+  call Function(bufnr, template_name, mock.function, 0, data, 0)
+
+  AssertEqual 1, mock.count
+  AssertEqual 1, len(mock.args[0])
+  AssertEqual expected, mock.args[0][0]
+

--- a/test/test_coc_source_job.vader
+++ b/test/test_coc_source_job.vader
@@ -1,0 +1,30 @@
+Before:
+  let b:script = 'autoload/coc/source/mediawiki.vim'
+  source test/utils.vim
+
+  call ClearSettings()
+
+  let Function = GetFunction(b:script, 'job')
+
+  let mock = NewFunctionMock()
+
+
+After:
+  unlet! Function
+  unlet! mock
+  unlet! shell_command
+  unlet! Callback
+
+
+Execute(Test coc#source#mediawiki#complete()):
+  let shell_command = ['echo', 'foobar']
+  let Callback = mock.function
+
+  call Function(shell_command, Callback)
+  sleep 500m
+
+  AssertEqual 1, len(mock.count)
+  AssertEqual 3, len(mock.args[0])
+  AssertEqual
+  \ ['foobar', ''],
+  \ mock.args[0][1]

--- a/test/test_coc_source_not_inside_template.vader
+++ b/test/test_coc_source_not_inside_template.vader
@@ -1,0 +1,88 @@
+Before:
+  let b:script = 'autoload/coc/source/mediawiki.vim'
+  source test/utils.vim
+
+  call ClearSettings()
+  call ClearSyntax()
+
+  let Function = GetFunction(b:script, 'not_inside_template')
+
+
+After:
+  call ClearSettings()
+  call ClearSyntax()
+
+  unlet! b:script
+
+  unlet! Function
+
+
+Given (Example text):
+  This is an example [[File:example.png|parameter|Description [[link|with pipe]] and some<ref>more</ref>]]
+
+  Example {{with|inline=template}} and {{ with | more = spacing }}.
+
+  {{Example
+  |with
+  |template=out
+   | of = lines
+  }}
+
+  Test <math>\text{inline math} \sin{x}</math>
+
+  :<math>
+    \text{and block math}
+  </math>
+
+  Test [https://foobar.com a link]
+Execute(Test s:not_inside_template()):
+  runtime syntax/mediawiki.vim
+  redraw
+
+  call cursor(1, 10)
+  Assert Function(), "Inside text"
+
+  call cursor(1, 38)
+  Assert Function(), "Inside wikilink"
+
+  call cursor(1, 38)
+  Assert Function(), "Inside wikilink"
+
+  call cursor(3, 16)
+  Assert !Function(), "Start of inline parameter name without spaces"
+
+  call cursor(3, 22)
+  Assert !Function(), "End of inline parameter name without spaces"
+
+  call cursor(3, 47)
+  Assert !Function(), "Start of inline parameter name with spaces"
+
+  call cursor(3, 52)
+  Assert !Function(), "End of inline parameter name with spaces"
+
+  call cursor(6, 2)
+  Assert !Function(), "Start of out-of-line parameter name"
+
+  call cursor(6, 5)
+  Assert !Function(), "End of out-of-line parameter name"
+
+  call cursor(6, 6)
+  Assert !Function(), "One char after end of of out-of-line parameter name"
+
+  call cursor(7, 2)
+  Assert !Function(), "Start of out-of-line parameter name with value"
+
+  call cursor(7, 9)
+  Assert !Function(), "End of out-of-line parameter name with value"
+
+  call cursor(7, 10)
+  Assert !Function(), "One char after end of of out-of-line parameter name with value"
+
+  call cursor(8, 3)
+  Assert !Function(), "Start of out-of-line parameter name with value and spaces"
+
+  call cursor(8, 6)
+  Assert !Function(), "End of out-of-line parameter name with value and spaces"
+
+  call cursor(8, 7)
+  Assert !Function(), "One char after end of of out-of-line parameter name with value and spaces"

--- a/test/test_coc_source_page_completion.vader
+++ b/test/test_coc_source_page_completion.vader
@@ -1,0 +1,55 @@
+Before:
+  let b:script = 'autoload/coc/source/mediawiki.vim'
+  source test/utils.vim
+
+  call ClearSettings()
+
+  let Function = GetFunction(b:script, 'page_completion')
+
+  let g:vim_mediawiki_site = 'some_site'
+  let g:vim_mediawiki_completion_prefix_length = 5
+  let g:vim_mediawiki_completion_limit = 5
+  let g:vim_mediawiki_completion_namespaces = {
+  \ 'default': {
+  \       '[[': 0,
+  \       '{{': 10,
+  \       '[[File:': 6,
+  \       '[[Category:': 14,
+  \   },
+  \ }
+
+  let mock = NewFunctionMock()
+
+
+After:
+  unlet! b:script
+  unlet! Function
+  unlet! mock
+  unlet! options
+  unlet! expected_command
+
+
+" Use a mock of the Python interpreter that echoes all its arguments
+Execute(Test s:page_completion()):
+  let expected_command = join([
+  \   '/testplugin/scripts/list_pages.py',
+  \   '--site', g:vim_mediawiki_site,
+  \   '--prefix', 'Some text',
+  \   '--namespace', string(g:vim_mediawiki_completion_namespaces['default']['[[']),
+  \   '--limit', string(g:vim_mediawiki_completion_limit),
+  \   ], ' ')
+
+  let options = {
+  \ 'bufnr': bufnr(''),
+  \ 'line': 'foo bar [[Some text and more]] after',
+  \ 'colnr': 20,
+  \ }
+
+  call Function(g:vim_mediawiki_site, options, mock.function)
+  sleep 500m
+
+  AssertEqual 1, len(mock.args[0])
+  AssertEqual
+  \ [{'word': expected_command, 'menu': expected_command}],
+  \ mock.args[0][0]
+

--- a/test/test_coc_source_should_complete.vader
+++ b/test/test_coc_source_should_complete.vader
@@ -2,6 +2,19 @@ Before:
   source test/utils.vim
 
   call ClearSettings()
+  call ClearSyntax()
+
+  runtime syntax/mediawiki.vim
+  redraw
+
+  function! PrepareLine(line, col)
+    call cursor(a:line, a:col)
+    return {
+    \ 'bufnr': bufnr(''),
+    \ 'line': getline(a:line),
+    \ 'colnr': a:col,
+    \ }
+  endfunction
 
   let g:vim_mediawiki_site = 'some_site'
   let g:vim_mediawiki_completion_prefix_length = 5
@@ -21,13 +34,28 @@ After:
   unlet! g:vim_mediawiki_site
   unlet! b:vim_mediawiki_site
 
+  call ClearSettings()
+  call ClearSyntax()
+
+  delfunction PrepareLine
+
+
+Given (Example text):
+  foo bar {{Some text and more}} after
+  foo bar {{#Some text and more}} after
+  foo bar [[Some|text and more]] after
+
+  Example {{with|inline=template}} and {{ with | more = spacing }}.
+
+  {{Example
+  |with
+  |template=out
+   | of = lines
+  }}
+
 
 Execute(Test coc#source#mediawiki#should_complete() with completion):
-  let options = {
-  \ 'bufnr': bufnr(''),
-  \ 'line': 'foo bar {{Some text and more}} after',
-  \ 'colnr': 20,
-  \ }
+  let options = PrepareLine(1, 20)
 
   Assert
   \ coc#source#mediawiki#should_complete(options),
@@ -35,11 +63,7 @@ Execute(Test coc#source#mediawiki#should_complete() with completion):
 
 
 Execute(Test coc#source#mediawiki#should_complete() on parser function):
-  let options = {
-  \ 'bufnr': bufnr(''),
-  \ 'line': 'foo bar {{#Some text and more}} after',
-  \ 'colnr': 20,
-  \ }
+  let options = PrepareLine(2, 20)
 
   Assert
   \ !coc#source#mediawiki#should_complete(options),
@@ -47,12 +71,25 @@ Execute(Test coc#source#mediawiki#should_complete() on parser function):
 
 
 Execute(Test coc#source#mediawiki#should_complete() after pipe):
-  let options = {
-  \ 'bufnr': bufnr(''),
-  \ 'line': 'foo bar [[Some|text and more]] after',
-  \ 'colnr': 20,
-  \ }
+  let options = PrepareLine(3, 20)
 
   Assert
   \ !coc#source#mediawiki#should_complete(options),
   \ 'Do not complete after a pipe'
+
+
+Execute(Test coc#source#mediawiki#should_complete() on template parameter name inline):
+  let options = PrepareLine(5, 22)
+
+  Assert
+  \ coc#source#mediawiki#should_complete(options),
+  \ 'Complete a template parameter name inline'
+
+
+Execute(Test coc#source#mediawiki#should_complete() on template parameter name out-of-line):
+  let options = PrepareLine(10, 7)
+
+  Assert
+  \ coc#source#mediawiki#should_complete(options),
+  \ 'Complete a template parameter name out-of-line'
+

--- a/test/test_coc_source_template_completion.vader
+++ b/test/test_coc_source_template_completion.vader
@@ -1,0 +1,28 @@
+Before:
+  let b:script = 'autoload/coc/source/mediawiki.vim'
+  source test/utils.vim
+
+  call ClearSettings()
+
+  let Function = GetFunction(b:script, 'template_completion')
+
+  let g:vim_mediawiki_site = 'some_site'
+
+  let mock = NewFunctionMock()
+
+
+After:
+  unlet! b:script
+  unlet! Function
+  unlet! mock
+
+
+" Use a mock of the Python interpreter that echoes all its arguments
+Execute(Test s:template_completion()):
+
+  call Function(bufnr(''), g:vim_mediawiki_site, mock.function)
+  sleep 500m
+
+  AssertEqual 1, mock.count
+  AssertEqual 1, len(mock.args[0])
+

--- a/test/test_get_templatedata.py
+++ b/test/test_get_templatedata.py
@@ -1,0 +1,109 @@
+import io
+import json
+import unittest
+import unittest.mock as mock
+
+import scripts.get_templatedata
+
+_params = {
+    "param1": {
+        "label": {
+            "en": "Label 1"
+        },
+        "description": {
+            "en": "Description 1"
+        },
+        "type": "string",
+        "required": False,
+        "suggested": False,
+        "example": None,
+        "deprecated": False,
+        "aliases": [],
+        "autovalue": None,
+        "default": None
+    },
+    "param2": {
+        "label": None,
+        "required": False,
+        "suggested": False,
+        "description": None,
+        "example": None,
+        "deprecated": False,
+        "aliases": [],
+        "autovalue": None,
+        "default": None,
+        "type": "unknown"
+    },
+}
+
+
+# Get an example API output with given tamplate name and parameters
+def get_expected_output(name='', params=None):
+    return {
+        "batchcomplete": "",
+        "pages": {} if params is None else {
+            "5474740": {
+                "title": name,
+                "description": {
+                    "en": "Template description"
+                },
+                "params": params,
+                "paramOrder": list(params.keys()),
+                "format": None,
+                "sets": [],
+                "maps": {}
+            }
+        }
+    }
+
+
+class TestGetTemplatedata(unittest.TestCase):
+
+    # Parametric sub-test
+    @mock.patch('sys.stdout', new_callable=io.StringIO)
+    @mock.patch('mwclient.Site', autospec=True)
+    def _test_main_for_params(self, template_name, expected_stdout, expected_output, site_mock, stdout_mock):
+        expected_site = 'some_site'
+        expected_method = 'templatedata'
+
+        api_mock = site_mock.return_value.api
+        api_mock.return_value = expected_output
+
+        argv = [
+            '--site', expected_site,
+            '--template', template_name,
+        ]
+
+        expected_args = {
+            'titles': template_name,
+            'format': 'jsonfm',
+            'redirects': True,
+        }
+
+        # Act
+        scripts.get_templatedata.main(argv)
+
+        # Assert
+        site_mock.assert_called_once_with(expected_site)
+        api_mock.assert_called_once_with(expected_method, **expected_args)
+        self.assertEqual(expected_stdout, stdout_mock.getvalue().strip())
+
+    def test_main(self):
+        template_name = 'Template:Some template'
+
+        # (template_name, expected_stdout, expected_output)
+        cases_to_test = [
+            # No pages returned by API (e.g. non-existant template name)
+            (template_name, json.dumps({}), get_expected_output()),
+            # Empty list of parameters returned by API
+            (template_name, json.dumps({}), get_expected_output(template_name, {})),
+            # Valid list of parameters returned by API
+            (template_name, json.dumps(_params), get_expected_output(template_name, _params)),
+        ]
+
+        for template_name, expected_stdout, expected_output in cases_to_test:
+            with self.subTest(template_name=template_name,
+                              expected_stdout=expected_stdout,
+                              expected_output=expected_output,
+                              ):
+                self._test_main_for_params(template_name, expected_stdout, expected_output)

--- a/test/test_syntax.vader
+++ b/test/test_syntax.vader
@@ -1,20 +1,16 @@
 Before:
   source test/utils.vim
-  function! Cleanup() abort
-    syntax clear
-    unlet! b:current_syntax
-    call ClearSettings()
-  endfunction
 
-  call Cleanup()
+  call ClearSettings()
+  call ClearSyntax()
 
 
 After:
-  call Cleanup()
-  delfunction Cleanup
+  call ClearSettings()
+  call ClearSyntax()
 
 
-Given mediawiki (Example text):
+Given (Example text):
   This is an example [[File:example.png|parameter|Description [[link|with pipe]] and some<ref>more</ref>]]
 
   Example {{with template|foo=bar}} and <div class="foo">some inline HTML tag</div>

--- a/test/utils.vim
+++ b/test/utils.vim
@@ -112,3 +112,9 @@ function! ClearSettings()
         unlet! b:{var}
     endfor
 endfunction
+
+" Clear current syntax highlighting
+function! ClearSyntax()
+    syntax clear
+    unlet! b:current_syntax
+endfunction


### PR DESCRIPTION
Implement semantic completion of template parameter names, based on the [TemplateData API](https://www.mediawiki.org/wiki/Extension:TemplateData#API).

Resolves #18 